### PR TITLE
Dynamic chunk loading

### DIFF
--- a/MinecraftRecreation/res/shaders/default/shader.vs
+++ b/MinecraftRecreation/res/shaders/default/shader.vs
@@ -14,6 +14,6 @@ void main()
 {
     gl_Position = projection * view * model * vec4(aPos, 1.0);
     oVertexColor = aColor;
-    //oVertexColor = aColor * vec3(aPos.z / 16);
+    oVertexColor = aColor * vec3(aPos.z / 16, aPos.x / 16, 0);
     oVertexTextureCoord = aTexCoord;
 } 

--- a/MinecraftRecreation/res/shaders/default/shader.vs
+++ b/MinecraftRecreation/res/shaders/default/shader.vs
@@ -14,6 +14,6 @@ void main()
 {
     gl_Position = projection * view * model * vec4(aPos, 1.0);
     oVertexColor = aColor;
-    oVertexColor = aColor * vec3(aPos.z / 16, aPos.x / 16, 0);
+    //oVertexColor = aColor * vec3(aPos.z / 16, aPos.x / 16, 0);
     oVertexTextureCoord = aTexCoord;
 } 

--- a/MinecraftRecreation/src/Application.cpp
+++ b/MinecraftRecreation/src/Application.cpp
@@ -83,7 +83,7 @@ void Application::start()
 
 void Application::mainloop()
 {
-    while (!glfwWindowShouldClose(window))
+    while (!glfwWindowShouldClose(window) && !shouldClose)
     {
         double t = glfwGetTime();
 
@@ -106,8 +106,11 @@ void Application::update()
 
 void Application::handleEvents()
 {
+
     if (glfwGetKey(window, GLFW_KEY_ESCAPE) == GLFW_PRESS)
-        glfwDestroyWindow(window);
+        shouldClose = true;
+    if(glfwGetKey(window, GLFW_KEY_SPACE) == GLFW_PRESS)
+        scene.deleteAllChunks();
 
     glfwPollEvents();
 }
@@ -129,6 +132,8 @@ void Application::render()
 
 void Application::terminate()
 {
+    glfwDestroyWindow(window);
+    window = nullptr;
     glfwTerminate();
     renderer.terminate();
 }

--- a/MinecraftRecreation/src/Application.cpp
+++ b/MinecraftRecreation/src/Application.cpp
@@ -75,7 +75,7 @@ void Application::start()
     renderer.initialize();
 
     double t = glfwGetTime();
-    scene.initChunkMap(glm::vec2(config::renderDistance, config::renderDistance), &textureAtlas);
+    scene.initChunkMap(&textureAtlas);
     std::cout << glfwGetTime() - t << " seconds to build the map\n";
 }
 

--- a/MinecraftRecreation/src/Application.cpp
+++ b/MinecraftRecreation/src/Application.cpp
@@ -93,7 +93,7 @@ void Application::mainloop()
         handleEvents();
 
         // The Framerate
-        //std::cout << 1 / (glfwGetTime() - t) << " frames per second\n";
+        std::cout << 1 / (glfwGetTime() - t) << " frames per second\n";
     }
 }
 

--- a/MinecraftRecreation/src/Application.cpp
+++ b/MinecraftRecreation/src/Application.cpp
@@ -93,7 +93,7 @@ void Application::mainloop()
         handleEvents();
 
         // The Framerate
-        //std::cout << 1 / (glfwGetTime() - t) << " frames per second\n";
+        std::cout << 1 / (glfwGetTime() - t) << " frames per second\n";
     }
 }
 
@@ -109,8 +109,6 @@ void Application::handleEvents()
 
     if (glfwGetKey(window, GLFW_KEY_ESCAPE) == GLFW_PRESS)
         shouldClose = true;
-    if(glfwGetKey(window, GLFW_KEY_SPACE) == GLFW_PRESS)
-        scene.deleteAllChunks();
 
     glfwPollEvents();
 }

--- a/MinecraftRecreation/src/Application.cpp
+++ b/MinecraftRecreation/src/Application.cpp
@@ -93,7 +93,7 @@ void Application::mainloop()
         handleEvents();
 
         // The Framerate
-        std::cout << 1 / (glfwGetTime() - t) << " frames per second\n";
+        //std::cout << 1 / (glfwGetTime() - t) << " frames per second\n";
     }
 }
 

--- a/MinecraftRecreation/src/Application.cpp
+++ b/MinecraftRecreation/src/Application.cpp
@@ -32,8 +32,8 @@ void Application::init()
         glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
         glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 
-        //window = glfwCreateWindow(config::resolutionX, config::resolutionY, "Minecraft Recreation", glfwGetPrimaryMonitor(), NULL);
-        window = glfwCreateWindow(config::resolutionX, config::resolutionY, "Minecraft Recreation", NULL, NULL);
+        window = glfwCreateWindow(config::resolutionX, config::resolutionY, "Minecraft Recreation", glfwGetPrimaryMonitor(), NULL);
+        //window = glfwCreateWindow(config::resolutionX, config::resolutionY, "Minecraft Recreation", NULL, NULL);
         glfwMaximizeWindow(window);
         if (!window)
         {
@@ -75,7 +75,7 @@ void Application::start()
     renderer.initialize();
 
     double t = glfwGetTime();
-    scene.initChunkMap(glm::vec2(32, 32), &textureAtlas);
+    scene.initChunkMap(glm::vec2(config::renderDistance, config::renderDistance), &textureAtlas);
     std::cout << glfwGetTime() - t << " seconds to build the map\n";
 }
 
@@ -100,6 +100,8 @@ void Application::mainloop()
 void Application::update()
 {
     camera.processKeyboard(window);
+
+    scene.update(&camera);
 }
 
 void Application::handleEvents()

--- a/MinecraftRecreation/src/Application.h
+++ b/MinecraftRecreation/src/Application.h
@@ -42,5 +42,7 @@ private:
 	void render();
 
 	void terminate();
+
+	bool shouldClose = false;
 };
 

--- a/MinecraftRecreation/src/Chunk.cpp
+++ b/MinecraftRecreation/src/Chunk.cpp
@@ -2,6 +2,18 @@
 
 #include "Scene.h"
 
+Chunk::~Chunk()
+{
+	/*
+	for (int i = 0; i < config::chunkWidth * config::chunkHeight * config::chunkLayers; i++)
+	{
+		if(blockBuffer[i])
+			blockBuffer[i] = nullptr;
+	}
+	delete[] blockBuffer;
+	*/
+}
+
 void Chunk::generateTerrain()
 {
 	for (int x = 0; x < config::chunkWidth; x++)
@@ -9,8 +21,11 @@ void Chunk::generateTerrain()
 		for (int z = 0; z < config::chunkHeight; z++)
 		{
 			glm::vec3 blockWorldPosition = getBlockWorldPosition(glm::vec3(x, 0, z));
-			float a = sin((blockWorldPosition.x + blockWorldPosition.z) * 0.1f);
-			int height = a * 3 + 16;
+			//float a = sin((blockWorldPosition.x * blockWorldPosition.z) * 0.1f);
+			//int height = a * 3 + 16;
+
+			int height = sin(x*2 * z+1 * 0.001f) * 5;
+
 			for (int y = 0; y < config::chunkLayers; y++)
 			{
 				int index = getIndexFromRelativePosition(x, y, z);

--- a/MinecraftRecreation/src/Chunk.cpp
+++ b/MinecraftRecreation/src/Chunk.cpp
@@ -4,14 +4,7 @@
 
 Chunk::~Chunk()
 {
-	/*
-	for (int i = 0; i < config::chunkWidth * config::chunkHeight * config::chunkLayers; i++)
-	{
-		if(blockBuffer[i])
-			blockBuffer[i] = nullptr;
-	}
-	delete[] blockBuffer;
-	*/
+	std::cout << sizeof(chunkMesh) << "\n";
 }
 
 void Chunk::generateTerrain()
@@ -21,10 +14,10 @@ void Chunk::generateTerrain()
 		for (int z = 0; z < config::chunkHeight; z++)
 		{
 			glm::vec3 blockWorldPosition = getBlockWorldPosition(glm::vec3(x, 0, z));
-			//float a = sin((blockWorldPosition.x * blockWorldPosition.z) * 0.1f);
-			//int height = a * 3 + 16;
+			float a = sin((blockWorldPosition.x * blockWorldPosition.z) * 0.1f);
+			int height = a * 3 + 16;
 
-			int height = sin(x*2 * z+1 * 0.001f) * 5;
+			//int height = sin(x*2 * z+1 * 0.001f) * 5;
 
 			for (int y = 0; y < config::chunkLayers; y++)
 			{

--- a/MinecraftRecreation/src/Chunk.cpp
+++ b/MinecraftRecreation/src/Chunk.cpp
@@ -4,7 +4,6 @@
 
 Chunk::~Chunk()
 {
-	chunkMesh.clean();
 
 	for (int i = 0; i < config::chunkWidth * config::chunkHeight * config::chunkLayers; i++)
 	{

--- a/MinecraftRecreation/src/Chunk.cpp
+++ b/MinecraftRecreation/src/Chunk.cpp
@@ -5,6 +5,11 @@
 Chunk::~Chunk()
 {
 	chunkMesh.clean();
+
+	for (int i = 0; i < config::chunkWidth * config::chunkHeight * config::chunkLayers; i++)
+	{
+		blockBuffer[i] = nullptr;
+	}
 }
 
 void Chunk::generateTerrain()

--- a/MinecraftRecreation/src/Chunk.cpp
+++ b/MinecraftRecreation/src/Chunk.cpp
@@ -4,7 +4,7 @@
 
 Chunk::~Chunk()
 {
-	std::cout << sizeof(chunkMesh) << "\n";
+	chunkMesh.clean();
 }
 
 void Chunk::generateTerrain()

--- a/MinecraftRecreation/src/Chunk.h
+++ b/MinecraftRecreation/src/Chunk.h
@@ -6,12 +6,13 @@
 #include "BlockDatabase.h"
 #include "TextureAtlas.h"
 
+
 class Chunk
 {
 public:
 	Chunk() {}
 	Chunk(glm::vec2 chunkPosition) {chunkWorldPosition = chunkPosition;}
-	~Chunk() {}
+	~Chunk();
 
 	void generateTerrain();
 	void generateChunkMesh(TextureAtlas* textureAtlas);
@@ -25,6 +26,7 @@ public:
 
 	glm::vec2 getWorldPosition() { return chunkWorldPosition; }
 	glm::vec3 getBlockWorldPosition(glm::vec3 relativeBlockPosition);
+
 	Mesh chunkMesh;
 private:
 	glm::vec2 chunkWorldPosition = glm::vec2(0,0);

--- a/MinecraftRecreation/src/Mesh.cpp
+++ b/MinecraftRecreation/src/Mesh.cpp
@@ -2,22 +2,24 @@
 
 void Mesh::loadMeshData(std::vector<Vertex>* Vertices)
 {
-	for (Vertex v : *Vertices)
-		vertices.push_back(v);
+	for (int i = 0; i < Vertices->size(); i++)
+	{
+		vertices.push_back(Vertices->at(i));
+	}
 }
 void Mesh::loadMeshData(std::vector<Vertex>* Vertices, glm::vec3 positionOffset)
 {
-	for (Vertex v : *Vertices)
+	for (int i = 0; i < Vertices->size(); i++)
 	{
-		vertices.push_back(v);
+		vertices.push_back(Vertices->at(i));
 		vertices.back().position += positionOffset;
 	}
 }
 void Mesh::loadMeshData(std::vector<Vertex>* Vertices, glm::vec3 positionOffset, glm::vec2 textureOffset)
 {
-	for (Vertex v : *Vertices)
+	for (int i = 0; i < Vertices->size(); i++)
 	{
-		vertices.push_back(v);
+		vertices.push_back(Vertices->at(i));
 		vertices.back().position += positionOffset;
 		vertices.back().textureCoordinate += textureOffset;
 	}
@@ -60,6 +62,8 @@ void Mesh::BindMeshBuffer()
 
 void Mesh::clean()
 {
+	vertices.clear();
+
 	glDeleteVertexArrays(1, &VAO);
 	glDeleteBuffers(1, &VBO);
 }

--- a/MinecraftRecreation/src/Mesh.cpp
+++ b/MinecraftRecreation/src/Mesh.cpp
@@ -71,8 +71,6 @@ void Mesh::clean()
 	glDeleteVertexArrays(1, &VAO);
 	glDeleteBuffers(1, &VBO);
 
-
-	std::cout << sizeof(Vertex) << std::endl;
 	vertices.erase(vertices.begin(), vertices.end());
 	vertices.clear();
 	vertices.shrink_to_fit();

--- a/MinecraftRecreation/src/Mesh.cpp
+++ b/MinecraftRecreation/src/Mesh.cpp
@@ -28,6 +28,12 @@ void Mesh::loadMeshData(std::vector<Vertex>* Vertices, glm::vec3 positionOffset,
 
 void Mesh::generateMeshBuffers()
 {
+	if (VBO != 0 || VAO != 0)
+	{
+		glDeleteVertexArrays(1, &VAO);
+		glDeleteBuffers(1, &VBO);
+	}
+
 	glGenVertexArrays(1, &VAO);
 	glGenBuffers(1, &VBO);
 
@@ -62,8 +68,13 @@ void Mesh::BindMeshBuffer()
 
 void Mesh::clean()
 {
-	vertices.clear();
-
 	glDeleteVertexArrays(1, &VAO);
 	glDeleteBuffers(1, &VBO);
+
+
+	std::cout << sizeof(Vertex) << std::endl;
+	vertices.erase(vertices.begin(), vertices.end());
+	vertices.clear();
+	vertices.shrink_to_fit();
+
 }

--- a/MinecraftRecreation/src/Mesh.h
+++ b/MinecraftRecreation/src/Mesh.h
@@ -15,7 +15,7 @@ class Mesh
 {
 public:
 	Mesh() { model = glm::mat4(1.0f); }
-	~Mesh() {}
+	~Mesh() {clean(); }
 
 	void setPosition(float x, float y, float z);
 

--- a/MinecraftRecreation/src/Mesh.h
+++ b/MinecraftRecreation/src/Mesh.h
@@ -35,6 +35,6 @@ private:
 	std::vector<Vertex> vertices;
 	glm::mat4 model;
 
-	unsigned int VAO = 0;
-	unsigned int VBO = 0;
+	GLuint VAO = 0;
+	GLuint VBO = 0;
 };

--- a/MinecraftRecreation/src/Scene.cpp
+++ b/MinecraftRecreation/src/Scene.cpp
@@ -18,14 +18,6 @@ void Scene::initChunkMap(TextureAtlas* textureAtlas)
 		}
 	}
     updateAllChunkEdges();
-
-    addChunkToGenerationQueue(glm::vec2(2, 2));
-    if(isPositionInChunkGenerationQueue(glm::vec2(2, 2)))
-        std::cout << "yup\n";
-    if(isPositionInChunkGenerationQueue(glm::vec2(2, 2)))
-        std::cout << "yup\n";
-    if(isPositionInChunkGenerationQueue(glm::vec2(1, 2)))
-        std::cout << "yup\n";
 }
 
 void Scene::chunkGenerationQueueManager()
@@ -158,8 +150,6 @@ void Scene::dynamicChunkLoading(Camera* camera)
     if (currentCameraChunkPos == lastCameraChunkPos)
         return;
 
-    std::vector<Chunk*> newChunks = std::vector<Chunk*>();
-
     //Load new chunks
     if (lastCameraChunkPos.x < currentCameraChunkPos.x)
     {
@@ -172,14 +162,20 @@ void Scene::dynamicChunkLoading(Camera* camera)
                 addChunkToGenerationQueue(newChunkPosition);
 
             // delete old chunk
-            Chunk* oldChunk = getChunk(glm::vec2(currentCameraChunkPos.x - config::renderDistance - 1, currentCameraChunkPos.y + i));
+
+            glm::vec2 oldChunkPosition = glm::vec2(currentCameraChunkPos.x - config::renderDistance - 1, currentCameraChunkPos.y + i);
+
+            if (isPositionInChunkGenerationQueue(oldChunkPosition))
+                removeChunkFromGenerationQueue(oldChunkPosition);
+
+            Chunk* oldChunk = getChunk(oldChunkPosition);
             while (oldChunk != nullptr)
             {
                 chunkMap.erase(std::remove(chunkMap.begin(), chunkMap.end(), oldChunk));
 
                 delete oldChunk;
 
-                oldChunk = getChunk(glm::vec2(currentCameraChunkPos.x - config::renderDistance - 1, currentCameraChunkPos.y + i));
+                oldChunk = getChunk(oldChunkPosition);
             }
         }
     }
@@ -195,14 +191,20 @@ void Scene::dynamicChunkLoading(Camera* camera)
                 addChunkToGenerationQueue(newChunkPosition);
 
             // delete old chunk
-            Chunk* oldChunk = getChunk(glm::vec2(currentCameraChunkPos.x + config::renderDistance + 1, currentCameraChunkPos.y + i));
+
+            glm::vec2 oldChunkPosition = glm::vec2(currentCameraChunkPos.x + config::renderDistance + 1, currentCameraChunkPos.y + i);
+
+            if (isPositionInChunkGenerationQueue(oldChunkPosition))
+                removeChunkFromGenerationQueue(oldChunkPosition);
+
+            Chunk* oldChunk = getChunk(oldChunkPosition);
             while (oldChunk != nullptr)
             {
                 chunkMap.erase(std::remove(chunkMap.begin(), chunkMap.end(), oldChunk));
 
                 delete oldChunk;
 
-                oldChunk = getChunk(glm::vec2(currentCameraChunkPos.x + config::renderDistance + 1, currentCameraChunkPos.y + i));
+                oldChunk = getChunk(oldChunkPosition);
             }
         }
     }
@@ -218,14 +220,20 @@ void Scene::dynamicChunkLoading(Camera* camera)
                 addChunkToGenerationQueue(newChunkPosition);
 
             // delete old chunk
-            Chunk* oldChunk = getChunk(glm::vec2(currentCameraChunkPos.x + i, currentCameraChunkPos.y - config::renderDistance - 1));
+
+            glm::vec2 oldChunkPosition = glm::vec2(currentCameraChunkPos.x + i, currentCameraChunkPos.y - config::renderDistance - 1);
+
+            if (isPositionInChunkGenerationQueue(oldChunkPosition))
+                removeChunkFromGenerationQueue(oldChunkPosition);
+
+            Chunk* oldChunk = getChunk(oldChunkPosition);
             while (oldChunk != nullptr)
             {
                 chunkMap.erase(std::remove(chunkMap.begin(), chunkMap.end(), oldChunk));
 
                 delete oldChunk;
 
-                oldChunk = getChunk(glm::vec2(currentCameraChunkPos.x + i, currentCameraChunkPos.y - config::renderDistance - 1));
+                oldChunk = getChunk(oldChunkPosition);
             }
         }
     }
@@ -242,14 +250,20 @@ void Scene::dynamicChunkLoading(Camera* camera)
             else
                 std::cout << newChunkPosition.x << ":" << newChunkPosition.y << "\n";
             // delete old chunk
-            Chunk* oldChunk = getChunk(glm::vec2(currentCameraChunkPos.x + i, currentCameraChunkPos.y + config::renderDistance + 1));
+            
+            glm::vec2 oldChunkPosition = glm::vec2(currentCameraChunkPos.x + i, currentCameraChunkPos.y + config::renderDistance + 1);
+
+            if(isPositionInChunkGenerationQueue(oldChunkPosition))
+                removeChunkFromGenerationQueue(oldChunkPosition);
+
+            Chunk* oldChunk = getChunk(oldChunkPosition);
             while (oldChunk != nullptr)
             {
                 chunkMap.erase(std::remove(chunkMap.begin(), chunkMap.end(), oldChunk));
 
                 delete oldChunk;
 
-                oldChunk = getChunk(glm::vec2(currentCameraChunkPos.x + i, currentCameraChunkPos.y + config::renderDistance + 1));
+                oldChunk = getChunk(oldChunkPosition);
             }
         }
     }
@@ -278,6 +292,14 @@ void Scene::addChunkToGenerationQueue(glm::vec2 chunkPosition)
     chunkGenerationQueue.push_back(chunkPosition);
 }
 
+void Scene::removeChunkFromGenerationQueue(glm::vec2 chunkPosition)
+{
+    auto it = std::find(chunkGenerationQueue.begin(), chunkGenerationQueue.end(), chunkPosition);
+    if (it != chunkGenerationQueue.end()) {
+        chunkGenerationQueue.erase(it);
+    }
+}
+
 bool Scene::isPositionInChunkGenerationQueue(glm::vec2 chunkPosition)
 {
     for (int i = 0; i < chunkGenerationQueue.size(); i++)
@@ -286,4 +308,18 @@ bool Scene::isPositionInChunkGenerationQueue(glm::vec2 chunkPosition)
             return true;
     }
     return false;
+}
+
+void Scene::deleteAllChunks()
+{
+    for (Chunk* chunk : chunkMap)
+    {
+        delete chunk;
+    }
+
+    std::cout << sizeof(Chunk) << std::endl;
+    std::cout << sizeof(Mesh) << std::endl;
+    std::cout << sizeof(BlockType*) * config::chunkWidth * config::chunkHeight * config::chunkLayers << std::endl;
+
+    chunkMap.clear();
 }

--- a/MinecraftRecreation/src/Scene.cpp
+++ b/MinecraftRecreation/src/Scene.cpp
@@ -3,104 +3,217 @@
 void Scene::initChunkMap(glm::vec2 size, TextureAtlas* textureAtlas)
 {
 	chunkMap.clear();
+    texture = textureAtlas;
 
-	for (int i = -size.x / 2; i <= size.x / 2; i++)
+	for (int i = config::renderDistance * -1; i <= config::renderDistance; i++)
 	{
-		for (int j = -size.y / 2; j < size.y / 2; j++)
+		for (int j = config::renderDistance * -1; j <= config::renderDistance; j++)
 		{
 			Chunk* newChunk = new Chunk(glm::vec2(i, j));
 
 			newChunk->generateTerrain();
-			newChunk->generateChunkMesh(textureAtlas);
+			newChunk->generateChunkMesh(texture);
 
 			chunkMap.push_back(newChunk);
 		}
 	}
 
-	updateChunkEdges(textureAtlas);
+    updateAllChunkEdges();
 }
 
-void Scene::updateChunkEdges(TextureAtlas* textureAtlas)
+void Scene::updateAllChunkEdges()
 {
     for (Chunk* chunk : chunkMap)
     {
-        // Check y- axis -- north
-        Chunk* northernChunk = getChunk(chunk->getWorldPosition() + glm::vec2(0, -1));
-        if (northernChunk != nullptr)
-        {
-            for (int x = 0; x < config::chunkWidth; x++)
-            {
-                for (int y = 0; y < config::chunkLayers; y++)
-                {
-                    BlockType* currentBlock = chunk->getBlockAtPosition(x, y, 0); // Fixed height position
-                    BlockType* northernBlock = northernChunk->getBlockAtPosition(x, y, config::chunkHeight - 1); // Fixed height position
-
-                    if (currentBlock->air == false && northernBlock->air == true)
-                    {
-                        chunk->chunkMesh.loadMeshData(&FaceData::FRONT, glm::vec3(x, y, 0), textureAtlas->getTextureCoordinateOffset(currentBlock->sideTexture));
-                    }
-                }
-            }
-        }
-
-        // Check y+ axis -- south
-        Chunk* southernChunk = getChunk(chunk->getWorldPosition() + glm::vec2(0, 1));
-        if (southernChunk != nullptr)
-        {
-            for (int x = 0; x < config::chunkWidth; x++)
-            {
-                for (int y = 0; y < config::chunkLayers; y++)
-                {
-                    BlockType* currentBlock = chunk->getBlockAtPosition(x, y, config::chunkHeight - 1); // Fixed height position
-                    BlockType* southernBlock = southernChunk->getBlockAtPosition(x, y, 0); // Fixed height position
-
-                    if (currentBlock->air == false && southernBlock->air == true)
-                    {
-                        chunk->chunkMesh.loadMeshData(&FaceData::BACK, glm::vec3(x, y, config::chunkHeight - 1), textureAtlas->getTextureCoordinateOffset(currentBlock->sideTexture));
-                    }
-                }
-            }
-        }
-
-        // Check x- axis -- west
-        Chunk* westernChunk = getChunk(chunk->getWorldPosition() + glm::vec2(-1, 0));
-        if (westernChunk != nullptr)
-        {
-            for (int z = 0; z < config::chunkHeight; z++) // Fixed loop limit
-            {
-                for (int y = 0; y < config::chunkLayers; y++)
-                {
-                    BlockType* currentBlock = chunk->getBlockAtPosition(0, y, z); // Fixed x position
-                    BlockType* westernBlock = westernChunk->getBlockAtPosition(config::chunkWidth - 1, y, z); // Fixed x position
-
-                    if (currentBlock->air == false && westernBlock->air == true)
-                    {
-                        chunk->chunkMesh.loadMeshData(&FaceData::LEFT, glm::vec3(0, y, z), textureAtlas->getTextureCoordinateOffset(currentBlock->sideTexture)); // Fixed position
-                    }
-                }
-            }
-        }
-
-        // Check x+ axis -- east
-        Chunk* easternChunk = getChunk(chunk->getWorldPosition() + glm::vec2(1, 0));
-        if (easternChunk != nullptr)
-        {
-            for (int z = 0; z < config::chunkHeight; z++) // Fixed loop limit
-            {
-                for (int y = 0; y < config::chunkLayers; y++)
-                {
-                    BlockType* currentBlock = chunk->getBlockAtPosition(config::chunkWidth - 1, y, z); // Fixed x position
-                    BlockType* easternBlock = easternChunk->getBlockAtPosition(0, y, z); // Fixed x position
-
-                    if (currentBlock->air == false && easternBlock->air == true)
-                    {
-                        chunk->chunkMesh.loadMeshData(&FaceData::RIGHT, glm::vec3(config::chunkWidth - 1, y, z), textureAtlas->getTextureCoordinateOffset(currentBlock->sideTexture)); // Fixed position
-                    }
-                }
-            }
-        }
-        chunk->updateChunkMeshBuffers();
+        updateChunkEdges(chunk);
     }
+}
+
+void Scene::updateChunkEdges(Chunk* chunk)
+{
+    // Check y- axis -- north
+    Chunk* northernChunk = getChunk(chunk->getWorldPosition() + glm::vec2(0, -1));
+    if (northernChunk != nullptr)
+    {
+        for (int x = 0; x < config::chunkWidth; x++)
+        {
+            for (int y = 0; y < config::chunkLayers; y++)
+            {
+                BlockType* currentBlock = chunk->getBlockAtPosition(x, y, 0);
+                BlockType* northernBlock = northernChunk->getBlockAtPosition(x, y, config::chunkHeight - 1);
+
+                if (currentBlock->air == false && northernBlock->air == true)
+                {
+                    chunk->chunkMesh.loadMeshData(&FaceData::FRONT, glm::vec3(x, y, 0), texture->getTextureCoordinateOffset(currentBlock->sideTexture));
+                }
+            }
+        }
+    }
+
+    // Check y+ axis -- south
+    Chunk* southernChunk = getChunk(chunk->getWorldPosition() + glm::vec2(0, 1));
+    if (southernChunk != nullptr)
+    {
+        for (int x = 0; x < config::chunkWidth; x++)
+        {
+            for (int y = 0; y < config::chunkLayers; y++)
+            {
+                BlockType* currentBlock = chunk->getBlockAtPosition(x, y, config::chunkHeight - 1);
+                BlockType* southernBlock = southernChunk->getBlockAtPosition(x, y, 0);
+
+                if (currentBlock->air == false && southernBlock->air == true)
+                {
+                    chunk->chunkMesh.loadMeshData(&FaceData::BACK, glm::vec3(x, y, config::chunkHeight - 1), texture->getTextureCoordinateOffset(currentBlock->sideTexture));
+                }
+            }
+        }
+    }
+
+    // Check x- axis -- west
+    Chunk* westernChunk = getChunk(chunk->getWorldPosition() + glm::vec2(-1, 0));
+    if (westernChunk != nullptr)
+    {
+        for (int z = 0; z < config::chunkHeight; z++)
+        {
+            for (int y = 0; y < config::chunkLayers; y++)
+            {
+                BlockType* currentBlock = chunk->getBlockAtPosition(0, y, z);
+                BlockType* westernBlock = westernChunk->getBlockAtPosition(config::chunkWidth - 1, y, z);
+
+                if (currentBlock->air == false && westernBlock->air == true)
+                {
+                    chunk->chunkMesh.loadMeshData(&FaceData::LEFT, glm::vec3(0, y, z), texture->getTextureCoordinateOffset(currentBlock->sideTexture));
+                }
+            }
+        }
+    }
+
+    // Check x+ axis -- east
+    Chunk* easternChunk = getChunk(chunk->getWorldPosition() + glm::vec2(1, 0));
+    if (easternChunk != nullptr)
+    {
+        for (int z = 0; z < config::chunkHeight; z++)
+        {
+            for (int y = 0; y < config::chunkLayers; y++)
+            {
+                BlockType* currentBlock = chunk->getBlockAtPosition(config::chunkWidth - 1, y, z);
+                BlockType* easternBlock = easternChunk->getBlockAtPosition(0, y, z);
+
+                if (currentBlock->air == false && easternBlock->air == true)
+                {
+                    chunk->chunkMesh.loadMeshData(&FaceData::RIGHT, glm::vec3(config::chunkWidth - 1, y, z), texture->getTextureCoordinateOffset(currentBlock->sideTexture));
+                }
+            }
+        }
+    }
+
+    chunk->updateChunkMeshBuffers();
+}
+
+void Scene::update(Camera* camera)
+{
+    glm::vec2 currentCameraChunkPos = glm::vec2(
+        floor(camera->position.x / config::chunkWidth),
+        floor(camera->position.z / config::chunkHeight));
+
+    if(currentCameraChunkPos == lastCameraChunkPos)
+        return;
+
+    std::vector<Chunk*> newChunks = std::vector<Chunk*>();
+
+    //Load new chunks
+    if (lastCameraChunkPos.x < currentCameraChunkPos.x)
+    {
+        //moved increase x
+        std::cout << "X+\n";
+        for (int i = config::renderDistance * -1; i <= config::renderDistance; i++)
+        {
+            Chunk* newChunk = new Chunk(glm::vec2(currentCameraChunkPos.x + config::renderDistance, currentCameraChunkPos.y + i));
+
+            newChunk->generateTerrain();
+            newChunk->generateChunkMesh(texture);
+
+            chunkMap.push_back(newChunk);
+            newChunks.push_back(newChunk);
+
+
+        }
+    }
+    if (lastCameraChunkPos.x > currentCameraChunkPos.x)
+    {
+        //moved decrease x
+        std::cout << "X-\n";
+        for (int i = config::renderDistance * -1; i <= config::renderDistance; i++)
+        {
+            Chunk* newChunk = new Chunk(glm::vec2(currentCameraChunkPos.x - config::renderDistance, currentCameraChunkPos.y + i));
+
+            newChunk->generateTerrain();
+            newChunk->generateChunkMesh(texture);
+
+            chunkMap.push_back(newChunk);
+            newChunks.push_back(newChunk);
+        }
+    }
+
+    if (lastCameraChunkPos.y < currentCameraChunkPos.y)
+    {
+        //move increased y
+        std::cout << "Y+\n";
+        for (int i = config::renderDistance * -1; i <= config::renderDistance; i++)
+        {
+            Chunk* newChunk = new Chunk(glm::vec2(currentCameraChunkPos.x + i, currentCameraChunkPos.y + config::renderDistance));
+
+            newChunk->generateTerrain();
+            newChunk->generateChunkMesh(texture);
+
+            chunkMap.push_back(newChunk);
+            newChunks.push_back(newChunk);
+        }
+    }
+    if (lastCameraChunkPos.y > currentCameraChunkPos.y)
+    {
+        //moved decreased y
+        std::cout << "Y-\n";
+        for (int i = config::renderDistance * -1; i <= config::renderDistance; i++)
+        {
+            Chunk* newChunk = new Chunk(glm::vec2(currentCameraChunkPos.x + i, currentCameraChunkPos.y - config::renderDistance));
+
+            newChunk->generateTerrain();
+            newChunk->generateChunkMesh(texture);
+
+            chunkMap.push_back(newChunk);
+            newChunks.push_back(newChunk);
+        }
+    }
+
+    for (Chunk* chunk : newChunks)
+    {
+        updateChunkEdges(chunk);
+        
+        std::vector<glm::vec2> directions = {glm::vec2(1, 0), glm::vec2(0, 1), glm::vec2(-1, 0), glm::vec2(0, -1)};
+        for (glm::vec2 dir : directions)
+        {
+            Chunk* neighbourChunk = getChunk(chunk->getWorldPosition() + dir);
+            if(neighbourChunk != nullptr)
+                updateChunkEdges(neighbourChunk);
+        }
+    }
+
+    lastCameraChunkPos = currentCameraChunkPos;
+}
+
+glm::vec2 Scene::generateChunkPosition(glm::vec2 direction, int chunkIndex, glm::vec2 cameraChunkPos)
+{
+    glm::vec2 absDirection = glm::vec2(abs(direction.x), abs(direction.y));
+    glm::vec2 negativeDirection = glm::vec2(absDirection.y, absDirection.x);
+
+    glm::vec2 iOffset = glm::vec2(cameraChunkPos.x + chunkIndex, cameraChunkPos.y + chunkIndex) * negativeDirection;
+
+    glm::vec2 renderDistanceOffset = glm::vec2(cameraChunkPos.x - config::renderDistance / 2, cameraChunkPos.y - config::renderDistance / 2) * absDirection;
+    if(direction.x + direction.y > 0)
+        renderDistanceOffset = glm::vec2(cameraChunkPos.x + config::renderDistance / 2, cameraChunkPos.y + config::renderDistance / 2) * absDirection;
+
+    return iOffset + renderDistanceOffset;
 }
 
 void Scene::renderScene(Renderer* renderer, Camera* camera)

--- a/MinecraftRecreation/src/Scene.cpp
+++ b/MinecraftRecreation/src/Scene.cpp
@@ -153,7 +153,6 @@ void Scene::dynamicChunkLoading(Camera* camera)
     //Load new chunks
     if (lastCameraChunkPos.x < currentCameraChunkPos.x)
     {
-        std::cout << "+X\n"; 
         //moved increase x
         for (int i = config::renderDistance * -1; i <= config::renderDistance; i++)
         {
@@ -181,7 +180,6 @@ void Scene::dynamicChunkLoading(Camera* camera)
     }
     if (lastCameraChunkPos.x > currentCameraChunkPos.x)
     {
-        std::cout << "-X\n";
         //moved decrease x
         for (int i = config::renderDistance * -1; i <= config::renderDistance; i++)
         {
@@ -211,7 +209,6 @@ void Scene::dynamicChunkLoading(Camera* camera)
 
     if (lastCameraChunkPos.y < currentCameraChunkPos.y)
     {
-        std::cout << "+Y\n";
         //move increased y
         for (int i = config::renderDistance * -1; i <= config::renderDistance; i++)
         {
@@ -239,9 +236,7 @@ void Scene::dynamicChunkLoading(Camera* camera)
     }
     if (lastCameraChunkPos.y > currentCameraChunkPos.y)
     {
-
         //moved decreased y
-        std::cout << "-Y\n";
         for (int i = config::renderDistance * -1; i <= config::renderDistance; i++)
         {
             glm::vec2 newChunkPosition = glm::vec2(currentCameraChunkPos.x + i, currentCameraChunkPos.y - config::renderDistance);

--- a/MinecraftRecreation/src/Scene.cpp
+++ b/MinecraftRecreation/src/Scene.cpp
@@ -194,15 +194,15 @@ void Scene::dynamicChunkLoading(Camera* camera)
 
             glm::vec2 oldChunkPosition = glm::vec2(currentCameraChunkPos.x + config::renderDistance + 1, currentCameraChunkPos.y + i);
 
-            if (isPositionInChunkGenerationQueue(oldChunkPosition))
-                removeChunkFromGenerationQueue(oldChunkPosition);
+                if (isPositionInChunkGenerationQueue(oldChunkPosition))
+                    removeChunkFromGenerationQueue(oldChunkPosition);
 
-            Chunk* oldChunk = getChunk(oldChunkPosition);
+                Chunk* oldChunk = getChunk(oldChunkPosition);
             while (oldChunk != nullptr)
-            {
-                chunkMap.erase(std::remove(chunkMap.begin(), chunkMap.end(), oldChunk));
+                {
+                    chunkMap.erase(std::remove(chunkMap.begin(), chunkMap.end(), oldChunk));
 
-                delete oldChunk;
+                    delete oldChunk;
 
                 oldChunk = getChunk(oldChunkPosition);
             }

--- a/MinecraftRecreation/src/Scene.cpp
+++ b/MinecraftRecreation/src/Scene.cpp
@@ -302,13 +302,3 @@ bool Scene::isPositionInChunkGenerationQueue(glm::vec2 chunkPosition)
     }
     return false;
 }
-
-void Scene::deleteAllChunks()
-{
-    for (Chunk* chunk : chunkMap)
-    {
-        delete chunk;
-    }
-
-    chunkMap.clear();
-}

--- a/MinecraftRecreation/src/Scene.cpp
+++ b/MinecraftRecreation/src/Scene.cpp
@@ -247,8 +247,6 @@ void Scene::dynamicChunkLoading(Camera* camera)
             glm::vec2 newChunkPosition = glm::vec2(currentCameraChunkPos.x + i, currentCameraChunkPos.y - config::renderDistance);
             if (getChunk(newChunkPosition) == nullptr && isPositionInChunkGenerationQueue(newChunkPosition) == false)
                 addChunkToGenerationQueue(newChunkPosition);
-            else
-                std::cout << newChunkPosition.x << ":" << newChunkPosition.y << "\n";
             // delete old chunk
             
             glm::vec2 oldChunkPosition = glm::vec2(currentCameraChunkPos.x + i, currentCameraChunkPos.y + config::renderDistance + 1);
@@ -316,10 +314,6 @@ void Scene::deleteAllChunks()
     {
         delete chunk;
     }
-
-    std::cout << sizeof(Chunk) << std::endl;
-    std::cout << sizeof(Mesh) << std::endl;
-    std::cout << sizeof(BlockType*) * config::chunkWidth * config::chunkHeight * config::chunkLayers << std::endl;
 
     chunkMap.clear();
 }

--- a/MinecraftRecreation/src/Scene.cpp
+++ b/MinecraftRecreation/src/Scene.cpp
@@ -112,11 +112,16 @@ void Scene::updateChunkEdges(Chunk* chunk)
 
 void Scene::update(Camera* camera)
 {
+    dynamicChunkLoading(camera);
+}
+
+void Scene::dynamicChunkLoading(Camera* camera)
+{
     glm::vec2 currentCameraChunkPos = glm::vec2(
         floor(camera->position.x / config::chunkWidth),
         floor(camera->position.z / config::chunkHeight));
 
-    if(currentCameraChunkPos == lastCameraChunkPos)
+    if (currentCameraChunkPos == lastCameraChunkPos)
         return;
 
     std::vector<Chunk*> newChunks = std::vector<Chunk*>();
@@ -125,76 +130,131 @@ void Scene::update(Camera* camera)
     if (lastCameraChunkPos.x < currentCameraChunkPos.x)
     {
         //moved increase x
-        std::cout << "X+\n";
         for (int i = config::renderDistance * -1; i <= config::renderDistance; i++)
         {
-            Chunk* newChunk = new Chunk(glm::vec2(currentCameraChunkPos.x + config::renderDistance, currentCameraChunkPos.y + i));
+            glm::vec2 newChunkPosition = glm::vec2(currentCameraChunkPos.x + config::renderDistance, currentCameraChunkPos.y + i);
+            if(getChunk(newChunkPosition) == nullptr)
+            {
+                Chunk* newChunk = new Chunk(newChunkPosition);
 
-            newChunk->generateTerrain();
-            newChunk->generateChunkMesh(texture);
+                newChunk->generateTerrain();
+                newChunk->generateChunkMesh(texture);
 
-            chunkMap.push_back(newChunk);
-            newChunks.push_back(newChunk);
+                chunkMap.push_back(newChunk);
+                newChunks.push_back(newChunk);
+            }
 
+            // delete old chunk
+            Chunk* oldChunk = getChunk(glm::vec2(currentCameraChunkPos.x - config::renderDistance - 1, currentCameraChunkPos.y + i));
+            while (oldChunk != nullptr)
+            {
+                chunkMap.erase(std::remove(chunkMap.begin(), chunkMap.end(), oldChunk));
 
+                delete oldChunk;
+
+                oldChunk = getChunk(glm::vec2(currentCameraChunkPos.x - config::renderDistance - 1, currentCameraChunkPos.y + i));
+            }
         }
     }
     if (lastCameraChunkPos.x > currentCameraChunkPos.x)
     {
         //moved decrease x
-        std::cout << "X-\n";
         for (int i = config::renderDistance * -1; i <= config::renderDistance; i++)
         {
-            Chunk* newChunk = new Chunk(glm::vec2(currentCameraChunkPos.x - config::renderDistance, currentCameraChunkPos.y + i));
+            // load new chunk
+            glm::vec2 newChunkPosition = glm::vec2(currentCameraChunkPos.x - config::renderDistance, currentCameraChunkPos.y + i);
+            if(getChunk(newChunkPosition) == nullptr)
+            {
+                Chunk* newChunk = new Chunk(newChunkPosition);
 
-            newChunk->generateTerrain();
-            newChunk->generateChunkMesh(texture);
+                newChunk->generateTerrain();
+                newChunk->generateChunkMesh(texture);
 
-            chunkMap.push_back(newChunk);
-            newChunks.push_back(newChunk);
+                chunkMap.push_back(newChunk);
+                newChunks.push_back(newChunk);
+            }
+
+            // delete old chunk
+            Chunk* oldChunk = getChunk(glm::vec2(currentCameraChunkPos.x + config::renderDistance + 1, currentCameraChunkPos.y + i));
+            while (oldChunk != nullptr)
+            {
+                chunkMap.erase(std::remove(chunkMap.begin(), chunkMap.end(), oldChunk));
+
+                delete oldChunk;
+
+                oldChunk = getChunk(glm::vec2(currentCameraChunkPos.x + config::renderDistance + 1, currentCameraChunkPos.y + i));
+            }
         }
     }
 
     if (lastCameraChunkPos.y < currentCameraChunkPos.y)
     {
         //move increased y
-        std::cout << "Y+\n";
         for (int i = config::renderDistance * -1; i <= config::renderDistance; i++)
         {
-            Chunk* newChunk = new Chunk(glm::vec2(currentCameraChunkPos.x + i, currentCameraChunkPos.y + config::renderDistance));
+            glm::vec2 newChunkPosition = glm::vec2(currentCameraChunkPos.x + i, currentCameraChunkPos.y + config::renderDistance);
+            if(getChunk(newChunkPosition) == nullptr)
+            {
+                Chunk* newChunk = new Chunk(newChunkPosition);
 
-            newChunk->generateTerrain();
-            newChunk->generateChunkMesh(texture);
+                newChunk->generateTerrain();
+                newChunk->generateChunkMesh(texture);
 
-            chunkMap.push_back(newChunk);
-            newChunks.push_back(newChunk);
+                chunkMap.push_back(newChunk);
+                newChunks.push_back(newChunk);
+            }
+
+            // delete old chunk
+            Chunk* oldChunk = getChunk(glm::vec2(currentCameraChunkPos.x + i, currentCameraChunkPos.y - config::renderDistance - 1));
+            while (oldChunk != nullptr)
+            {
+                chunkMap.erase(std::remove(chunkMap.begin(), chunkMap.end(), oldChunk));
+
+                delete oldChunk;
+
+                oldChunk = getChunk(glm::vec2(currentCameraChunkPos.x + i, currentCameraChunkPos.y - config::renderDistance - 1));
+            }
         }
     }
     if (lastCameraChunkPos.y > currentCameraChunkPos.y)
     {
         //moved decreased y
-        std::cout << "Y-\n";
         for (int i = config::renderDistance * -1; i <= config::renderDistance; i++)
         {
-            Chunk* newChunk = new Chunk(glm::vec2(currentCameraChunkPos.x + i, currentCameraChunkPos.y - config::renderDistance));
+            glm::vec2 newChunkPosition = glm::vec2(currentCameraChunkPos.x + i, currentCameraChunkPos.y - config::renderDistance);
+            if(getChunk(newChunkPosition) == nullptr)
+            {
+                Chunk* newChunk = new Chunk(newChunkPosition);
 
-            newChunk->generateTerrain();
-            newChunk->generateChunkMesh(texture);
+                newChunk->generateTerrain();
+                newChunk->generateChunkMesh(texture);
 
-            chunkMap.push_back(newChunk);
-            newChunks.push_back(newChunk);
+                chunkMap.push_back(newChunk);
+                newChunks.push_back(newChunk);
+            }
+
+            // delete old chunk
+            Chunk* oldChunk = getChunk(glm::vec2(currentCameraChunkPos.x + i, currentCameraChunkPos.y + config::renderDistance + 1));
+            while (oldChunk != nullptr)
+            {
+                chunkMap.erase(std::remove(chunkMap.begin(), chunkMap.end(), oldChunk));
+
+                delete oldChunk;
+
+                oldChunk = getChunk(glm::vec2(currentCameraChunkPos.x + i, currentCameraChunkPos.y + config::renderDistance + 1));
+            }
         }
     }
 
     for (Chunk* chunk : newChunks)
     {
         updateChunkEdges(chunk);
-        
-        std::vector<glm::vec2> directions = {glm::vec2(1, 0), glm::vec2(0, 1), glm::vec2(-1, 0), glm::vec2(0, -1)};
+
+        std::vector<glm::vec2> directions = { glm::vec2(1, 0), glm::vec2(0, 1), glm::vec2(-1, 0), glm::vec2(0, -1) };
         for (glm::vec2 dir : directions)
         {
             Chunk* neighbourChunk = getChunk(chunk->getWorldPosition() + dir);
-            if(neighbourChunk != nullptr)
+            if (neighbourChunk != nullptr)
                 updateChunkEdges(neighbourChunk);
         }
     }

--- a/MinecraftRecreation/src/Scene.h
+++ b/MinecraftRecreation/src/Scene.h
@@ -26,4 +26,6 @@ private:
 
 	void updateAllChunkEdges();
 	void updateChunkEdges(Chunk* chunk);
+
+	void dynamicChunkLoading(Camera* camera);
 };

--- a/MinecraftRecreation/src/Scene.h
+++ b/MinecraftRecreation/src/Scene.h
@@ -12,11 +12,18 @@ class Scene
 public:
 	void initChunkMap(glm::vec2 size, TextureAtlas* textureAtlas);
 
+	void update(Camera* camera);
 	void renderScene(Renderer* renderer, Camera* camera);
 
 	Chunk* getChunk(glm::vec2 chunkPosition);
 private:
-	std::vector<Chunk*> chunkMap;
+	TextureAtlas* texture;
 
-	void updateChunkEdges(TextureAtlas* textureAtlas);
+	std::vector<Chunk*> chunkMap;
+	glm::vec2 lastCameraChunkPos = glm::vec2(0,0);
+
+	glm::vec2 generateChunkPosition(glm::vec2 direction, int chunkIndex, glm::vec2 cameraChunkPos);
+
+	void updateAllChunkEdges();
+	void updateChunkEdges(Chunk* chunk);
 };

--- a/MinecraftRecreation/src/Scene.h
+++ b/MinecraftRecreation/src/Scene.h
@@ -1,6 +1,12 @@
 #pragma once
 
 #include <vector>
+#include <queue>
+#include <deque>
+#include <algorithm>
+
+#include "GL/glew.h"
+#include "GLFW/glfw3.h"
 
 #include "Chunk.h"
 #include "Renderer.h"
@@ -10,7 +16,7 @@
 class Scene
 {
 public:
-	void initChunkMap(glm::vec2 size, TextureAtlas* textureAtlas);
+	void initChunkMap(TextureAtlas* textureAtlas);
 
 	void update(Camera* camera);
 	void renderScene(Renderer* renderer, Camera* camera);
@@ -20,12 +26,17 @@ private:
 	TextureAtlas* texture;
 
 	std::vector<Chunk*> chunkMap;
-	glm::vec2 lastCameraChunkPos = glm::vec2(0,0);
+	std::deque<glm::vec2> chunkGenerationQueue;
 
-	glm::vec2 generateChunkPosition(glm::vec2 direction, int chunkIndex, glm::vec2 cameraChunkPos);
+	glm::vec2 lastCameraChunkPos = glm::vec2(0,0);
 
 	void updateAllChunkEdges();
 	void updateChunkEdges(Chunk* chunk);
 
 	void dynamicChunkLoading(Camera* camera);
+	void chunkGenerationQueueManager();
+
+	double chunkGenerationAllowance = (1.0f / 1000.0f) * 2.0f;
+	void addChunkToGenerationQueue(glm::vec2 chunkPosition);
+	bool isPositionInChunkGenerationQueue(glm::vec2 chunkPosition);
 };

--- a/MinecraftRecreation/src/Scene.h
+++ b/MinecraftRecreation/src/Scene.h
@@ -20,8 +20,6 @@ public:
 
 	void update(Camera* camera);
 	void renderScene(Renderer* renderer, Camera* camera);
-
-	void deleteAllChunks();
 	
 	Chunk* getChunk(glm::vec2 chunkPosition);
 private:

--- a/MinecraftRecreation/src/Scene.h
+++ b/MinecraftRecreation/src/Scene.h
@@ -21,6 +21,8 @@ public:
 	void update(Camera* camera);
 	void renderScene(Renderer* renderer, Camera* camera);
 
+	void deleteAllChunks();
+	
 	Chunk* getChunk(glm::vec2 chunkPosition);
 private:
 	TextureAtlas* texture;
@@ -38,5 +40,6 @@ private:
 
 	double chunkGenerationAllowance = (1.0f / 1000.0f) * 2.0f;
 	void addChunkToGenerationQueue(glm::vec2 chunkPosition);
+	void removeChunkFromGenerationQueue(glm::vec2 chunkPosition);
 	bool isPositionInChunkGenerationQueue(glm::vec2 chunkPosition);
 };

--- a/MinecraftRecreation/src/config.h
+++ b/MinecraftRecreation/src/config.h
@@ -16,8 +16,8 @@ struct config {
 	const static int pitch = 0;
 
 	// World Settings
-	const static unsigned int chunkWidth = 32;
-	const static unsigned int chunkHeight = 32;
+	const static unsigned int chunkWidth = 64;
+	const static unsigned int chunkHeight = 64;
 	const static unsigned int chunkLayers = 64;
 
 	const static int renderDistance = 32;

--- a/MinecraftRecreation/src/config.h
+++ b/MinecraftRecreation/src/config.h
@@ -16,9 +16,9 @@ struct config {
 	const static int pitch = 0;
 
 	// World Settings
-	const static unsigned int chunkWidth = 16;
-	const static unsigned int chunkHeight = 16;
+	const static unsigned int chunkWidth = 32;
+	const static unsigned int chunkHeight = 32;
 	const static unsigned int chunkLayers = 64;
 
-	const static int renderDistance = 8;
+	const static int renderDistance = 32;
 };

--- a/MinecraftRecreation/src/config.h
+++ b/MinecraftRecreation/src/config.h
@@ -16,8 +16,8 @@ struct config {
 	const static int pitch = 0;
 
 	// World Settings
-	const static unsigned int chunkWidth = 16;
-	const static unsigned int chunkHeight = 16;
+	const static unsigned int chunkWidth = 32;
+	const static unsigned int chunkHeight = 32;
 	const static unsigned int chunkLayers = 64;
 
 	const static int renderDistance = 8;

--- a/MinecraftRecreation/src/config.h
+++ b/MinecraftRecreation/src/config.h
@@ -16,9 +16,9 @@ struct config {
 	const static int pitch = 0;
 
 	// World Settings
-	const static unsigned int chunkWidth = 64;
-	const static unsigned int chunkHeight = 64;
+	const static unsigned int chunkWidth = 16;
+	const static unsigned int chunkHeight = 16;
 	const static unsigned int chunkLayers = 64;
 
-	const static int renderDistance = 32;
+	const static int renderDistance = 8;
 };

--- a/MinecraftRecreation/src/config.h
+++ b/MinecraftRecreation/src/config.h
@@ -18,5 +18,7 @@ struct config {
 	// World Settings
 	const static unsigned int chunkWidth = 16;
 	const static unsigned int chunkHeight = 16;
-	const static unsigned int chunkLayers = 128;
+	const static unsigned int chunkLayers = 64;
+
+	const static int renderDistance = 8;
 };

--- a/MinecraftRecreation/src/main.cpp
+++ b/MinecraftRecreation/src/main.cpp
@@ -1,5 +1,7 @@
 #include "Application.h"
 
+//TODO: fix memory leak :)
+
 int main(void)
 {
     Application* application = new Application();


### PR DESCRIPTION
During implementation had a major memory leak issue, where every time a new chunk was generated, a large sum of memory was leaked.

resolution: found the memory being leaked was on the graphics card, making me realize that despite cleaning up a mesh's data after its finished life, we didn't clean the OpenGL buffers whenever the chunk mesh was updated, leading the memory to leak.